### PR TITLE
Changed iOS build settings to default to x64 so iOS 10.1 won't give warnings on boot

### DIFF
--- a/Demos/app-imagesearch-cogs/ImageSearch/ImageSearch.iOS/Entitlements.plist
+++ b/Demos/app-imagesearch-cogs/ImageSearch/ImageSearch.iOS/Entitlements.plist
@@ -1,6 +1,5 @@
-﻿<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-</dict>
+<dict/>
 </plist>

--- a/Demos/app-imagesearch-cogs/ImageSearch/ImageSearch.iOS/ImageSearch.iOS.csproj
+++ b/Demos/app-imagesearch-cogs/ImageSearch/ImageSearch.iOS/ImageSearch.iOS.csproj
@@ -21,10 +21,22 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-    <MtouchArch>i386</MtouchArch>
+    <MtouchArch>x86_64</MtouchArch>
     <MtouchLink>None</MtouchLink>
-    <MtouchDebug>true</MtouchDebug>
-    <MtouchProfiling>true</MtouchProfiling>
+    <MtouchDebug>True</MtouchDebug>
+    <MtouchProfiling>False</MtouchProfiling>
+    <MtouchSdkVersion>10.1</MtouchSdkVersion>
+    <MtouchFastDev>False</MtouchFastDev>
+    <MtouchUseLlvm>False</MtouchUseLlvm>
+    <MtouchUseThumb>False</MtouchUseThumb>
+    <MtouchEnableBitcode>False</MtouchEnableBitcode>
+    <MtouchUseSGen>False</MtouchUseSGen>
+    <MtouchUseRefCounting>False</MtouchUseRefCounting>
+    <OptimizePNGs>True</OptimizePNGs>
+    <MtouchTlsProvider>Default</MtouchTlsProvider>
+    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <MtouchFloat32>False</MtouchFloat32>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>full</DebugType>
@@ -58,9 +70,23 @@
     <ConsolePause>false</ConsolePause>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
-    <MtouchProfiling>true</MtouchProfiling>
+    <MtouchProfiling>False</MtouchProfiling>
     <CodesignKey>iPhone Developer</CodesignKey>
-    <MtouchDebug>true</MtouchDebug>
+    <MtouchDebug>True</MtouchDebug>
+    <PlatformTarget>x64</PlatformTarget>
+    <MtouchSdkVersion>10.1</MtouchSdkVersion>
+    <MtouchLink>SdkOnly</MtouchLink>
+    <MtouchFastDev>False</MtouchFastDev>
+    <MtouchUseLlvm>False</MtouchUseLlvm>
+    <MtouchUseThumb>False</MtouchUseThumb>
+    <MtouchEnableBitcode>False</MtouchEnableBitcode>
+    <MtouchUseSGen>False</MtouchUseSGen>
+    <MtouchUseRefCounting>False</MtouchUseRefCounting>
+    <OptimizePNGs>True</OptimizePNGs>
+    <MtouchTlsProvider>Default</MtouchTlsProvider>
+    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <MtouchFloat32>False</MtouchFloat32>
+    <DeviceSpecificBuild>False</DeviceSpecificBuild>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Acr.Support.iOS, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">

--- a/Demos/app-imagesearch-cogs/ImageSearch/ImageSearch.iOS/Info.plist
+++ b/Demos/app-imagesearch-cogs/ImageSearch/ImageSearch.iOS/Info.plist
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -13,7 +13,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>
-	<string>8.1</string>
+	<string>9.1</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>
@@ -46,7 +46,7 @@
 	<string>Resources/Images.xcassets/AppIcons.appiconset</string>
 	<key>XSLaunchImageAssets</key>
 	<string>Resources/Images.xcassets/LaunchImage.launchimage</string>
-  <key>NSLocationWhenInUseUsageDescription</key>
-  <string>Location to get photos nearby.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Location to get photos nearby.</string>
 </dict>
 </plist>

--- a/Demos/app-imagesearch-cogs/ImageSearch/ImageSearch/Services/ServiceKeys.cs
+++ b/Demos/app-imagesearch-cogs/ImageSearch/ImageSearch/Services/ServiceKeys.cs
@@ -9,7 +9,7 @@ namespace ImageSearch.Services
     public class CognitiveServicesKeys
     {
 		//Setup a Bing Search API key from: http://www.microsoft.com/cognitive-services
-		public const string BingSearch = "f40aa3da36b2409ba0e2c41cf420a9b6";
+		public const string BingSearch = "f06bce968421495ab0286de6f83b8035";
 
 	} 
 }

--- a/Demos/app-imagesearch-cogs/ImageSearch/ImageSearch/Services/ServiceKeys.cs
+++ b/Demos/app-imagesearch-cogs/ImageSearch/ImageSearch/Services/ServiceKeys.cs
@@ -9,7 +9,7 @@ namespace ImageSearch.Services
     public class CognitiveServicesKeys
     {
 		//Setup a Bing Search API key from: http://www.microsoft.com/cognitive-services
-		public const string BingSearch = "f06bce968421495ab0286de6f83b8035";
+		public const string BingSearch = "f40aa3da36b2409ba0e2c41cf420a9b6";
 
 	} 
 }

--- a/Demos/app-myweather/MyWeather.iOS/MyWeather.iOS.csproj
+++ b/Demos/app-myweather/MyWeather.iOS/MyWeather.iOS.csproj
@@ -21,10 +21,12 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-    <MtouchArch>i386</MtouchArch>
+    <MtouchArch>x86_64</MtouchArch>
     <MtouchLink>None</MtouchLink>
     <MtouchDebug>true</MtouchDebug>
     <MtouchProfiling>true</MtouchProfiling>
+<MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+<CodesignKey>iPhone Developer</CodesignKey>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>full</DebugType>
@@ -128,6 +130,7 @@
   <ItemGroup>
     <ProjectReference Include="..\MyWeather\MyWeather.csproj">
       <Name>MyWeather</Name>
+      <Project>{5366CC83-65A3-4969-B883-3229108447E2}</Project>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/Demos/app-tasks/DevDaysTasks.iOS/DevDaysTasks.iOS.csproj
+++ b/Demos/app-tasks/DevDaysTasks.iOS/DevDaysTasks.iOS.csproj
@@ -21,7 +21,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-    <MtouchArch>i386</MtouchArch>
+    <MtouchArch>x86_64</MtouchArch>
     <MtouchLink>None</MtouchLink>
     <MtouchDebug>true</MtouchDebug>
     <MtouchProfiling>true</MtouchProfiling>


### PR DESCRIPTION
When i did this demo for some people they asked questions why iOS was complaining that the app was slowing the OS down. 

popup looks like this (other random app screenshot i found on google)
![img](http://toucharcade.com/wp-content/uploads/2016/10/IMG_0814-620x310.png)

by setting default to X64 this message does not show.