### PR TITLE
ReadMe change with CognitiveServices RecognizeAsync call to prevent BadRequest error

### DIFF
--- a/HandsOnLab/README.md
+++ b/HandsOnLab/README.md
@@ -635,12 +635,10 @@ Follow these steps:
 public class EmotionService
 {
     private static async Task<Emotion[]> GetHappinessAsync(string url)
-    {
-        var client = new HttpClient();
-        var stream = await client.GetStreamAsync(url);
+    {        
         var emotionClient = new EmotionServiceClient("INSERT_EMOTION_SERVICE_KEY_HERE");
 
-        var emotionResults = await emotionClient.RecognizeAsync(stream);
+        var emotionResults = await emotionClient.RecognizeAsync(url);
 
         if (emotionResults == null || emotionResults.Count() == 0)
         {


### PR DESCRIPTION
Current code provided in the readme passes a stream to emotionClient.RecognizeAsync, this results in a BadRequest error. Passing the url directly works as intended.